### PR TITLE
fix link address of movie icon and opeamp photo icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
                 <td class="smallcell"><img src="img/Logo_example3.png"></td>
                 <!--大きなセル-->
                 <td colspan="2" rowspan="2" class="bigcell"><img src="img/ex2.png"></td>
-                <td class="smallcell"><a href="all_movies/all_movies.html"><img src="img/micon_photo.png"></a></td>
+                <td class="smallcell"><a href="https://youhaveniceboat.pythonanywhere.com"><img src="img/micon_photo.png"></a></td>
                 <td class="smallcell"><a href="all_movies/all_movies.html"><img src="img/microcontroller_new.png"></a></td>
             </tr>
             <!-- 2行目 -->
@@ -41,7 +41,7 @@
             </tr>
             <!-- 3行目 -->
             <tr id="thirdrow">
-                <td class="smallcell"><a href="https://youhaveniceboat.pythonanywhere.com"><img src="img/movie_new.png"></a></td>
+                <td class="smallcell"><a href="all_movies/all_movies.html"><img src="img/movie_new.png"></a></td>
                 <td class="smallcell"><img src="img/transistor_photo.png"></td>
                 <td class="smallcell"><a href="ABOUT US/index.html"><img src="img/about_new.png"></a></td>
                 <td class="smallcell"><a href="https://youhaveniceboat.pythonanywhere.com"><img src="img/resistance_photo.png"></a></td>


### PR DESCRIPTION
Movieのアイコンはムービーページ行ったほうがいいと思うので修正。
逆にマイコン写真がムービーページのままだったのでそちらはていのいいに飛ぶように。